### PR TITLE
Applied PCA Transformation + Solved Dimension Error

### DIFF
--- a/Gaussian Discriminant Analysis.ipynb
+++ b/Gaussian Discriminant Analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 255,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": 256,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
     "    x_minus_mu = x-mu\n",
     "    x_minus_mu = x_minus_mu.reshape(*(x_minus_mu.shape), 1)\n",
     "    expval = (np.matmul((x-mu),np.linalg.inv(sigma)))\n",
-    "    return ((1/(((2*pi)**(dim/2))*np.sqrt(np.linalg.det(sigma))))*np.exp(-0.5*(np.dot(expval, (x-mu).T))))\n",
+    "    return ((1/(((2*pi)**(dim/2))*np.sqrt(np.linalg.det(sigma))))*np.exp(-0.5*(np.matmul(expval, (x-mu).T))))\n",
     "\n",
     "def cal_py(y, phi):\n",
     "    if (y==1):\n",
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": 257,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 258,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,37 +107,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": 259,
    "metadata": {},
    "outputs": [],
    "source": [
     "phi1 =  cal_phi(ytrain1)\n",
     "mu1_1 = cal_mu1(xtrain1,ytrain1)\n",
     "mu0_1 = cal_mu0(xtrain1,ytrain1)\n",
-    "sig1 = cal_sigma(xtrain1, ytrain1, mu0_1, mu1_1)\n",
-    "\n",
-    "px_y0_1 = px_py(xtest1, mu0_1, sig1)*cal_py(0, phi1)\n",
-    "px_y1_1 = px_py(xtest1, mu1_1, sig1)*cal_py(0, phi1)"
+    "sig1 = cal_sigma(xtrain1, ytrain1, mu0_1, mu1_1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 260,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "accuracy -> [0.55]\n"
+      "accuracy -> [0.83]\n"
      ]
     }
    ],
    "source": [
     "m = len(ytest1)\n",
     "y_pred1 = np.zeros_like(ytest1)\n",
-    "for i in range(m):\n",
-    "    if (np.sum(px_y0_1[i]) > np.sum(px_y1_1[i])):\n",
+    "for i in range(m):   \n",
+    "    px_y0_1 = px_py(xtest1[i], mu0_1, sig1)*cal_py(0, phi1)\n",
+    "    px_y1_1 = px_py(xtest1[i], mu1_1, sig1)*cal_py(0, phi1)\n",
+    "    if (px_y0_1 > px_y1_1):\n",
     "        y_pred1[i]=0\n",
     "    else:\n",
     "        y_pred1[i]=1\n",
@@ -146,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 261,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 262,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,14 +173,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 263,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "accuracy -> [0.92]\n"
+      "accuracy -> [0.91]\n"
      ]
     }
    ],
@@ -191,109 +190,16 @@
     "mu0_2 = cal_mu0(xtrain2,ytrain2)\n",
     "sig2 = cal_sigma(xtrain2, ytrain2, mu0_2, mu1_2)\n",
     "\n",
-    "px_y0_2 = px_py(xtest2, mu0_2, sig2)*cal_py(0, phi2)\n",
-    "px_y1_2 = px_py(xtest2, mu1_2, sig2)*cal_py(0, phi2)\n",
-    "\n",
     "m = len(ytest2)\n",
     "y_pred2 = np.zeros_like(ytest2)\n",
     "for i in range(m):\n",
-    "    if (np.sum(px_y0_2[i]) > np.sum(px_y1_2[i])):\n",
+    "    px_y0_2 = px_py(xtest2[i], mu0_2, sig2)*cal_py(0, phi2)\n",
+    "    px_y1_2 = px_py(xtest2[i], mu1_2, sig2)*cal_py(0, phi2)\n",
+    "    if (px_y0_2 > px_y1_2):\n",
     "        y_pred2[i]=0\n",
     "    else:\n",
     "        y_pred2[i]=1\n",
     "print('accuracy -> {}'.format(sum(y_pred2 == ytest2)/ytest2.shape[0]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 190,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(100, 2)"
-      ]
-     },
-     "execution_count": 190,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "np.shape((np.matmul((xtest1-mu0_1),np.linalg.inv(sig1))))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 191,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(2, 100)"
-      ]
-     },
-     "execution_count": 191,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "np.shape((xtest1-mu0_1).T)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 196,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "6.346898189797457e-05"
-      ]
-     },
-     "execution_count": 196,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "((1/(((2*3.14)**(len(mu0_1/2))*np.sqrt(np.linalg.det(sig1))))))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 235,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.02533589, 0.0582253 , 0.03989009, ..., 0.15495648, 0.24112024,\n",
-       "        0.12700978],\n",
-       "       [0.0582253 , 0.0614262 , 0.05795623, ..., 0.07306605, 0.08814404,\n",
-       "        0.11100685],\n",
-       "       [0.03989009, 0.05795623, 0.04745388, ..., 0.09925219, 0.13949339,\n",
-       "        0.13328721],\n",
-       "       ...,\n",
-       "       [0.15495648, 0.07306605, 0.09925219, ..., 0.03387583, 0.02683623,\n",
-       "        0.06364463],\n",
-       "       [0.24112024, 0.08814404, 0.13949339, ..., 0.02683623, 0.0155986 ,\n",
-       "        0.03341614],\n",
-       "       [0.12700978, 0.11100685, 0.13328721, ..., 0.06364463, 0.03341614,\n",
-       "        0.01393846]])"
-      ]
-     },
-     "execution_count": 235,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "px_y1_2"
    ]
   },
   {

--- a/Gaussian Discriminant Analysis.ipynb
+++ b/Gaussian Discriminant Analysis.ipynb
@@ -2,17 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 225,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from sklearn.decomposition import PCA"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 226,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,9 +23,9 @@
     "def cal_mu1(x,y):\n",
     "    m = len(y)\n",
     "    y_pos = np.sum(y==0)\n",
-    "    conditional_sum_x = np.zeros_like(x.iloc[1,:], dtype=np.float64)\n",
+    "    conditional_sum_x = np.zeros_like(x[1,:], dtype=np.float64)\n",
     "    for i in range(m):\n",
-    "        xi = x.iloc[i,:]\n",
+    "        xi = x[i,:]\n",
     "        yi = y[i]\n",
     "        if (yi==1):\n",
     "            conditional_sum_x += xi\n",
@@ -35,10 +36,10 @@
     "def cal_mu0(x,y):\n",
     "    m = len(y)\n",
     "    y_neg = np.sum(y==1)\n",
-    "    conditional_sum_x = np.zeros_like(x.iloc[1,:])\n",
+    "    conditional_sum_x = np.zeros_like(x[1,:])\n",
     "    for i in range(m):\n",
-    "        xi = x.iloc[i,:]\n",
-    "        yi = y.iloc[i]\n",
+    "        xi = x[i,:]\n",
+    "        yi = y[i]\n",
     "        if (yi==0):\n",
     "            conditional_sum_x += xi\n",
     "        else:\n",
@@ -48,14 +49,14 @@
     "def cal_sigma(x, y, mu0, mu1):\n",
     "    mu = [mu0, mu1]\n",
     "    m = len(y)\n",
-    "    x=x.to_numpy()\n",
+    "    # x=x.to_numpy()\n",
     "    x_minus_mu = x[0] - mu[int(y[0])]\n",
-    "    x_minus_mu = x_minus_mu.values.reshape(*(x_minus_mu.shape), 1)\n",
+    "    x_minus_mu = x_minus_mu.reshape(*(x_minus_mu.shape), 1)\n",
     "    s = np.matmul(x_minus_mu, x_minus_mu.T)\n",
     " \n",
     "    for i in range(1, m):\n",
     "        x_minus_mu = x[i] - mu[int(y[i])]\n",
-    "        x_minus_mu = x_minus_mu.values.reshape(*(x_minus_mu.shape), 1)\n",
+    "        x_minus_mu = x_minus_mu.reshape(*(x_minus_mu.shape), 1)\n",
     "        s += np.matmul(x_minus_mu, x_minus_mu.T)\n",
     "    s = s/m\n",
     "    return(s)\n",
@@ -64,9 +65,9 @@
     "    pi = 3.1415926535\n",
     "    dim = len(mu)\n",
     "    x_minus_mu = x-mu\n",
-    "    x_minus_mu = x_minus_mu.values.reshape(*(x_minus_mu.shape), 1)\n",
+    "    x_minus_mu = x_minus_mu.reshape(*(x_minus_mu.shape), 1)\n",
     "    expval = (np.matmul((x-mu),np.linalg.inv(sigma)))\n",
-    "    return ((1/(((2*pi)**(dim/2))*np.sqrt(np.linalg.det(sigma))))*np.exp(-0.5*(np.dot(expval,(x-mu).T))))\n",
+    "    return ((1/(((2*pi)**(dim/2))*np.sqrt(np.linalg.det(sigma))))*np.exp(-0.5*(np.dot(expval, (x-mu).T))))\n",
     "\n",
     "def cal_py(y, phi):\n",
     "    if (y==1):\n",
@@ -77,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,12 +88,26 @@
     "xtrain1 = dtrain1[['x_1','x_2']]\n",
     "ytrain1 = dtrain1['y']\n",
     "xtest1 = dtest1[['x_1','x_2']]\n",
-    "ytest1 = dtest1['y']\n"
+    "ytest1 = dtest1['y']\n",
+    "ytest1 = ytest1.values.reshape(*(ytest1.shape), 1)\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 228,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pca = PCA(n_components=2)\n",
+    "pca.fit(xtrain1)\n",
+    "xtrain1 = pca.transform(xtrain1)\n",
+    "xtest1 = pca.transform(xtest1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,46 +122,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[1.64505313e-04, 1.43045952e-04, 1.57980056e-04, ...,\n",
-       "        1.56266137e-04, 1.37898325e-04, 1.63086580e-04],\n",
-       "       [1.43045952e-04, 1.10728112e-04, 1.26323457e-04, ...,\n",
-       "        1.20354238e-04, 9.96768049e-05, 1.30166358e-04],\n",
-       "       [1.57980056e-04, 1.26323457e-04, 1.22226395e-04, ...,\n",
-       "        1.07741958e-04, 1.03017836e-04, 1.15409398e-04],\n",
-       "       ...,\n",
-       "       [1.56266137e-04, 1.20354238e-04, 1.07741958e-04, ...,\n",
-       "        8.92595071e-05, 8.98021603e-05, 9.67347638e-05],\n",
-       "       [1.37898325e-04, 9.96768049e-05, 1.03017836e-04, ...,\n",
-       "        8.98021603e-05, 7.88174797e-05, 9.92086119e-05],\n",
-       "       [1.63086580e-04, 1.30166358e-04, 1.15409398e-04, ...,\n",
-       "        9.67347638e-05, 9.92086119e-05, 1.03696478e-04]])"
-      ]
-     },
-     "execution_count": 135,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "px_y0_1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 230,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "accuracy -> 0.24\n"
+      "accuracy -> [0.55]\n"
      ]
     }
    ],
@@ -163,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 231,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,19 +156,32 @@
     "xtrain2 = dtrain2[['x_1','x_2']]\n",
     "ytrain2 = dtrain2['y']\n",
     "xtest2 = dtest2[['x_1','x_2']]\n",
-    "ytest2 = dtest2['y']\n"
+    "ytest2 = dtest2['y']\n",
+    "ytest2 = ytest2.values.reshape(*(ytest2.shape), 1)\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 232,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pca.fit(xtrain2)\n",
+    "xtrain2 = pca.transform(xtrain2)\n",
+    "xtest2 = pca.transform(xtest2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 233,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "accuracy -> 0.89\n"
+      "accuracy -> [0.92]\n"
      ]
     }
    ],
@@ -210,91 +206,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[0.38264832, 0.66220221, 0.46359646, ..., 0.48541294, 0.73550078,\n",
-       "        0.39997161],\n",
-       "       [0.66220221, 1.17437855, 0.91084258, ..., 1.0076553 , 1.38466805,\n",
-       "        0.85090744],\n",
-       "       [0.46359646, 0.91084258, 0.97678402, ..., 1.22905587, 1.31872978,\n",
-       "        1.09156248],\n",
-       "       ...,\n",
-       "       [0.48541294, 1.0076553 , 1.22905587, ..., 1.60543818, 1.59331599,\n",
-       "        1.44458838],\n",
-       "       [0.73550078, 1.38466805, 1.31872978, ..., 1.59331599, 1.85426446,\n",
-       "        1.39408441],\n",
-       "       [0.39997161, 0.85090744, 1.09156248, ..., 1.44458838, 1.39408441,\n",
-       "        1.30559775]])"
+       "(100, 2)"
       ]
      },
-     "execution_count": 342,
+     "execution_count": 190,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "expval = np.matmul((xtest1-mu0_1),np.linalg.inv(sig2))\n",
-    "np.dot(expval,(xtest1-mu0_1).T)"
+    "np.shape((np.matmul((xtest1-mu0_1),np.linalg.inv(sig1))))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 191,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "x_1      3.771027\n",
-       "x_2    343.987218\n",
-       "dtype: float64"
+       "(2, 100)"
       ]
      },
-     "execution_count": 233,
+     "execution_count": 191,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mu = [mu0,mu1]\n",
-    "s = xtr.loc[1,:]-mu[int(ytr[1])]\n",
-    "s "
+    "np.shape((xtest1-mu0_1).T)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 196,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[65.81247502, 57.22738056, 63.20196162, ..., 62.51628624,\n",
-       "        55.16800573, 65.2448925 ],\n",
-       "       [57.22738056, 44.29821115, 50.53733057, ..., 48.14926727,\n",
-       "        39.87699316, 52.0747326 ],\n",
-       "       [63.20196162, 50.53733057, 48.89824776, ..., 43.10356196,\n",
-       "        41.21361564, 46.1710201 ],\n",
-       "       ...,\n",
-       "       [62.51628624, 48.14926727, 43.10356196, ..., 35.70941864,\n",
-       "        35.92651405, 38.69999161],\n",
-       "       [55.16800573, 39.87699316, 41.21361564, ..., 35.92651405,\n",
-       "        31.53195073, 39.68968649],\n",
-       "       [65.2448925 , 52.0747326 , 46.1710201 , ..., 38.69999161,\n",
-       "        39.68968649, 41.48511525]])"
+       "6.346898189797457e-05"
       ]
      },
-     "execution_count": 347,
+     "execution_count": 196,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "px_y0_1"
+    "((1/(((2*3.14)**(len(mu0_1/2))*np.sqrt(np.linalg.det(sig1))))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0.02533589, 0.0582253 , 0.03989009, ..., 0.15495648, 0.24112024,\n",
+       "        0.12700978],\n",
+       "       [0.0582253 , 0.0614262 , 0.05795623, ..., 0.07306605, 0.08814404,\n",
+       "        0.11100685],\n",
+       "       [0.03989009, 0.05795623, 0.04745388, ..., 0.09925219, 0.13949339,\n",
+       "        0.13328721],\n",
+       "       ...,\n",
+       "       [0.15495648, 0.07306605, 0.09925219, ..., 0.03387583, 0.02683623,\n",
+       "        0.06364463],\n",
+       "       [0.24112024, 0.08814404, 0.13949339, ..., 0.02683623, 0.0155986 ,\n",
+       "        0.03341614],\n",
+       "       [0.12700978, 0.11100685, 0.13328721, ..., 0.06364463, 0.03341614,\n",
+       "        0.01393846]])"
+      ]
+     },
+     "execution_count": 235,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "px_y1_2"
    ]
   },
   {
@@ -302,22 +301,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "m = len(y)\n",
-    "mu = [mu0, mu1]\n",
-    "x_minus_mu = x.iloc[1,:] - mu[int(y[1])]\n",
-    "x_minus_mu = np.reshape(*(x_minus_mu.shape), 1)\n",
-    "sqr_sum = np.matmul(x_minus_mu, x_minus_mu.T)\n",
-    "for i in range(m):\n",
-    "    xi = x.iloc[i,:]\n",
-    "    yi = y[i]\n",
-    "    if (yi==1):\n",
-    "        sqr = (xi-mu1)*(xi-mu1)\n",
-    "    else:\n",
-    "        sqr = (xi-mu0)*(xi-mu0)\n",
-    "    sqr_sum += sqr\n",
-    "return sqr_sum/m"
-   ]
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
1. Applied PCA tranform with n_components = 2 on x datasets. This improved accuracy to 55% on ds1 and 92% on ds2.
2. Calculated prior probability for each test instance within a for loop -> removed dimensional error and brought accuracy up to 83% on ds1 and 91% on ds2.